### PR TITLE
KP-6208 Ubuntu-based runner

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,13 +1,14 @@
-FROM centos:7
+FROM ubuntu:22.04
 
 ARG ACTIONS_RUNNER_VERSION="2.298.2"
 ARG ACTIONS_RUNNER_CHECKSUM="0bfd792196ce0ec6f1c65d2a9ad00215b2926ef2c416b8d97615265194477117"
 
-RUN yum install epel-release -y
-RUN yum update -y
-RUN yum install perl-Digest-SHA jq python3 pip3 -y
+RUN apt-get update -y
+RUN apt-get install curl libssl-dev libdigest-sha-perl jq python3 python3-pip -y
 
-RUN useradd --no-log-init -u 1031660001 kprunner
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+RUN useradd --home-dir /home/kprunner --create-home --no-log-init -u 1031660001 kprunner
 
 USER kprunner
 

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update -y
 RUN apt-get install curl libssl-dev libdigest-sha-perl jq python3 python3-pip -y
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN pip install --upgrade pip
 
 RUN useradd --home-dir /home/kprunner --create-home --no-log-init -u 1031660001 kprunner
 

--- a/runner/README.md
+++ b/runner/README.md
@@ -5,7 +5,7 @@ You need a personal access token for creating a local runner.
 
 After that you can build and start a runner with
 ```
-docker build . -t runnr
+docker build . -t runner
 docker run runner [PAT]
 ```
 

--- a/service/pod.yaml
+++ b/service/pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: runner-container
-    image: "docker-registry.default.svc:5000/kielipankki-github-runners/runner:v1.1.0"
+    image: "docker-registry.default.svc:5000/kielipankki-github-runners/runner:v2.0.0"
     workingDir: /home/kprunner
     args: ["$(GITHUB_PAT)"]
     env:

--- a/workflows/unit-test-python.yml
+++ b/workflows/unit-test-python.yml
@@ -1,6 +1,6 @@
 name: Python unit tests
 
-on: 
+on:
   pull_request:
     types:
       - opened
@@ -19,6 +19,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install required Python packages
-      run: pip3 install -r requirements_dev.txt --user
+      run: pip install -r requirements_dev.txt --user
     - name: Test with pytest
-      run: python3 -m pytest
+      run: python -m pytest


### PR DESCRIPTION
On CentOS 7 it's hard to get new-enough Python to fulfill Airflow needs. Thus we are now testing and intend to run on production
using Ubuntu instead.

The Ubuntu 22.04 Docker image apparently does not come with Python preinstalled, so it is installed hand. For easy using, it is also symlinked to be invoked via `python` in addition to `python3`.

Pip is also updated as part of the container creation to ensure that we are not running on an ancient version (which causes problems, see e.g. https://github.com/CSCfi/kielipankki-nlf-harvester/actions/runs/3370303814/jobs/5607236192).