### PR TITLE
KP-7378 Add second runner for publishing course materials

### DIFF
--- a/runners/README.md
+++ b/runners/README.md
@@ -7,7 +7,7 @@ After that you can navigate to the desired runner's directory and build and
 start it with
 ```
 docker build . -t [runner-name]   # runner-name can be e.g. "python-runner"
-docker run python-runner [PAT]
+docker run --env RUNNER_REPO='[organization/repository]' python-runner [PAT]
 ```
 
 ### Cleanup old local containers

--- a/runners/course-runner/Dockerfile
+++ b/runners/course-runner/Dockerfile
@@ -1,0 +1,51 @@
+FROM ubuntu:22.04
+
+# Basic setup
+
+RUN apt-get update -y
+RUN apt-get upgrade -y
+
+RUN apt-get install curl wget libssl-dev libdigest-sha-perl jq build-essential libssl-dev uuid-dev libgpgme11-dev squashfs-tools libseccomp-dev pkg-config -y
+
+RUN export LANG=fi_FI.utf8
+RUN export LC_ALL=fi_FI.utf8
+
+# GitHub actions runner
+
+ARG ACTIONS_RUNNER_VERSION="2.306.0"
+ARG ACTIONS_RUNNER_CHECKSUM="b0a090336f0d0a439dac7505475a1fb822f61bbb36420c7b3b3fe6b1bdc4dbaa"
+
+RUN useradd --home-dir /home/kprunner --create-home --no-log-init -u 1031660001 kprunner
+USER kprunner
+
+RUN mkdir /home/kprunner/runner
+WORKDIR /home/kprunner/runner
+
+RUN curl -o "actions-runner-linux-x64-$ACTIONS_RUNNER_VERSION.tar.gz" -L "https://github.com/actions/runner/releases/download/v$ACTIONS_RUNNER_VERSION/actions-runner-linux-x64-$ACTIONS_RUNNER_VERSION.tar.gz"
+RUN echo "$ACTIONS_RUNNER_CHECKSUM  actions-runner-linux-x64-$ACTIONS_RUNNER_VERSION.tar.gz" | shasum -a 256 -c
+RUN tar xzf "./actions-runner-linux-x64-$ACTIONS_RUNNER_VERSION.tar.gz"
+
+ADD bin /home/kprunner/
+
+USER root
+RUN /home/kprunner/runner/bin/installdependencies.sh
+
+RUN apt-get install python3-pip pandoc python3-pandocfilters fonts-noto fonts-inconsolata git cabal-install nvi -y
+
+RUN cabal update
+RUN mkdir -p /root/.cabal/bin
+RUN cabal install pandoc-types-1.17.5.4 pandoc-emphasize-code
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+USER kprunner
+WORKDIR /home/kprunner
+
+RUN git clone https://github.com/csc-training/slide-template
+WORKDIR /home/kprunner/slide-template
+RUN make git
+ENV PATH="$PATH:/home/kprunner/lib/slidefactory"
+
+USER kprunner
+WORKDIR /home/kprunner
+ENTRYPOINT ["/bin/bash", "/home/kprunner/runner-setup.sh"]

--- a/runners/course-runner/Dockerfile
+++ b/runners/course-runner/Dockerfile
@@ -32,7 +32,7 @@ RUN /home/kprunner/runner/bin/installdependencies.sh
 
 # Install pandoc for MD -> HTML
 
-RUN apt-get install python3-pip pandoc python3-pandocfilters fonts-noto fonts-inconsolata git cabal-install nvi -y
+RUN apt-get install python3-pip pandoc python3-pandocfilters fonts-noto fonts-inconsolata git cabal-install -y
 
 RUN cabal update
 RUN mkdir -p /root/.cabal/bin

--- a/runners/course-runner/Dockerfile
+++ b/runners/course-runner/Dockerfile
@@ -30,22 +30,31 @@ ADD bin /home/kprunner/
 USER root
 RUN /home/kprunner/runner/bin/installdependencies.sh
 
+# Install pandoc for MD -> HTML
+
 RUN apt-get install python3-pip pandoc python3-pandocfilters fonts-noto fonts-inconsolata git cabal-install nvi -y
 
 RUN cabal update
 RUN mkdir -p /root/.cabal/bin
 RUN cabal install pandoc-types-1.17.5.4 pandoc-emphasize-code
 
-RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN ln -s /usr/bin/python3 /usr/bin/python  # convert.py shebang wants /usr/bin/python
 
 USER kprunner
 WORKDIR /home/kprunner
+
+# For slides
 
 RUN git clone https://github.com/csc-training/slide-template
 WORKDIR /home/kprunner/slide-template
 RUN make git
 ENV PATH="$PATH:/home/kprunner/lib/slidefactory"
 
-USER kprunner
+# For handouts/tutorials
+
 WORKDIR /home/kprunner
+RUN mkdir -p .pandoc/templates
+RUN wget https://raw.githubusercontent.com/tajmone/pandoc-goodies/master/templates/html5/github/GitHub.html5 -O .pandoc/templates/GitHub.html5
+
+
 ENTRYPOINT ["/bin/bash", "/home/kprunner/runner-setup.sh"]

--- a/runners/course-runner/README.md
+++ b/runners/course-runner/README.md
@@ -1,0 +1,3 @@
+# Docker Image for Building GitHub Pages for Course Material
+
+The handouts are generated using [GitHub Template v2.2](https://github.com/tajmone/pandoc-goodies/tree/master/templates/html5/github) (under [MIT license](https://github.com/tajmone/pandoc-goodies/blob/master/templates/html5/github/LICENSE)) by Tristano Ajmone.

--- a/runners/course-runner/bin/batch-md-to-html.sh
+++ b/runners/course-runner/bin/batch-md-to-html.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if [ $# -ne 2 ]
+then
+  echo "Usage: batch-convert.sh input/directory output/dir"
+  exit 1
+fi
+
+original_dir=`pwd`
+source_dir=$1
+destination_dir=$2
+
+# We need to `cd` or the relative paths in the md files won't work
+cd $source_dir
+
+for mdfile in *.md; do
+	convert.py --self-contained $mdfile
+done
+
+# This allows using relative path for the output directory
+cd $original_dir
+for htmlfile in $source_dir/*.html; do
+	mv $htmlfile $destination_dir/
+done

--- a/runners/course-runner/bin/convert-single-page.sh
+++ b/runners/course-runner/bin/convert-single-page.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ $# -ne 2 ]
+then
+  echo "Usage: convert-single-page.sh file.md output/file.html"
+  exit 1
+fi
+
+source_file=$1
+destination_file=$2
+
+pandoc --template=GitHub.html5 --self-contained $source_file -o $destination_file

--- a/runners/course-runner/bin/convert-slides.sh
+++ b/runners/course-runner/bin/convert-slides.sh
@@ -2,7 +2,7 @@
 
 if [ $# -ne 2 ]
 then
-  echo "Usage: batch-convert.sh input/directory output/dir"
+  echo "Usage: convert-slides.sh input/directory output/dir"
   exit 1
 fi
 

--- a/runners/course-runner/bin/convert-tutorials.sh
+++ b/runners/course-runner/bin/convert-tutorials.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [ $# -ne 2 ]
+then
+  echo "Usage: convert-tutorials.sh input/directory output/dir"
+  exit 1
+fi
+
+original_dir=`pwd`
+source_dir=$1
+destination_dir=$2
+
+# We need to `cd` or the relative paths in the md files won't work
+cd $source_dir
+
+for mdfile in *.md; do
+  ~/convert-single-page.sh $mdfile $original_dir/$destination_dir/"${mdfile%.md}.html"
+done
+

--- a/runners/course-runner/bin/runner-setup.sh
+++ b/runners/course-runner/bin/runner-setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+HEADER="$(echo "Authorization: Bearer $1" | tr -d '\n')"
+REPO="aajarven/Kielipankki"
+
+TOKEN_RESPONSE=$(wget --method=post -O- -q --header="Accept: application/vnd.github+json" --header="$HEADER" https://api.github.com/repos/$REPO/actions/runners/registration-token)
+TOKEN=$(echo $TOKEN_RESPONSE | jq --raw-output ".token")
+
+/home/kprunner/runner/config.sh --url https://github.com/$REPO --ephemeral --unattended --token $TOKEN
+/home/kprunner/runner/run.sh

--- a/runners/course-runner/bin/runner-setup.sh
+++ b/runners/course-runner/bin/runner-setup.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 
 HEADER="$(echo "Authorization: Bearer $1" | tr -d '\n')"
-REPO="aajarven/Kielipankki"
 
-TOKEN_RESPONSE=$(wget --method=post -O- -q --header="Accept: application/vnd.github+json" --header="$HEADER" https://api.github.com/repos/$REPO/actions/runners/registration-token)
+TOKEN_RESPONSE=$(wget --method=post -O- -q --header="Accept: application/vnd.github+json" --header="$HEADER" https://api.github.com/repos/$RUNNER_REPO/actions/runners/registration-token)
 TOKEN=$(echo $TOKEN_RESPONSE | jq --raw-output ".token")
 
-/home/kprunner/runner/config.sh --url https://github.com/$REPO --ephemeral --unattended --token $TOKEN
+/home/kprunner/runner/config.sh --url https://github.com/$RUNNER_REPO --ephemeral --unattended --token $TOKEN
 /home/kprunner/runner/run.sh

--- a/runners/python-runner/bin/runner-setup.sh
+++ b/runners/python-runner/bin/runner-setup.sh
@@ -2,8 +2,8 @@
 
 HEADER="$(echo "Authorization: Bearer $1" | tr -d '\n')"
 
-TOKEN_RESPONSE=$(wget --method=post -O- -q --header="Accept: application/vnd.github+json" --header="$HEADER" https://api.github.com/repos/CSCfi/kielipankki-nlf-harvester/actions/runners/registration-token)
+TOKEN_RESPONSE=$(wget --method=post -O- -q --header="Accept: application/vnd.github+json" --header="$HEADER" https://api.github.com/repos/$RUNNER_REPO/actions/runners/registration-token)
 TOKEN=$(echo $TOKEN_RESPONSE | jq --raw-output ".token")
 
-/home/kprunner/runner/config.sh --url https://github.com/CSCfi/kielipankki-nlf-harvester --ephemeral --unattended --token $TOKEN
+/home/kprunner/runner/config.sh --url https://github.com/$RUNNER_REPO --ephemeral --unattended --token $TOKEN
 /home/kprunner/runner/run.sh

--- a/services/course-runner-pod.yaml
+++ b/services/course-runner-pod.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: runner-container
-      image: "docker-registry.default.svc:5000/kielipankki-github-runners/course-runner:v0.0.2"
+      image: "docker-registry.default.svc:5000/kielipankki-github-runners/course-runner:v1.0.0"
       workingDir: /home/kprunner
       args: ["$(GITHUB_PAT)"]
       env:

--- a/services/course-runner-pod.yaml
+++ b/services/course-runner-pod.yaml
@@ -1,0 +1,21 @@
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: kp-course-runner-
+spec:
+  containers:
+    - name: runner-container
+      image: "docker-registry.default.svc:5000/kielipankki-github-runners/course-runner:v0.0.1"
+      workingDir: /home/kprunner
+      args: ["$(GITHUB_PAT)"]
+      env:
+        - name: GITHUB_PAT
+          valueFrom:
+            secretKeyRef:
+              name: runner-secrets
+              key: gh_runner_pat
+              optional: false
+  securityContext:
+    runAsUser: 1031660001

--- a/services/course-runner-pod.yaml
+++ b/services/course-runner-pod.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: runner-container
-      image: "docker-registry.default.svc:5000/kielipankki-github-runners/course-runner:v0.0.1"
+      image: "docker-registry.default.svc:5000/kielipankki-github-runners/course-runner:v0.0.2"
       workingDir: /home/kprunner
       args: ["$(GITHUB_PAT)"]
       env:
@@ -17,5 +17,7 @@ spec:
               name: runner-secrets
               key: gh_runner_pat
               optional: false
+        - name: RUNNER_REPO
+          value: "aajarven/Kielipankki"
   securityContext:
     runAsUser: 1031660001

--- a/services/course-runner-pod.yaml
+++ b/services/course-runner-pod.yaml
@@ -18,6 +18,6 @@ spec:
               key: gh_runner_pat
               optional: false
         - name: RUNNER_REPO
-          value: "aajarven/Kielipankki"
+          value: "csc-training/Kielipankki"
   securityContext:
     runAsUser: 1031660001

--- a/services/python-runner-pod.yaml
+++ b/services/python-runner-pod.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  generateName: kp-runner-
+  generateName: kp-python-runner-
 spec:
   containers:
     - name: runner-container
-      image: "docker-registry.default.svc:5000/kielipankki-github-runners/python-runner:v1.0.2"
+      image: "docker-registry.default.svc:5000/kielipankki-github-runners/python-runner:v1.1.0"
       workingDir: /home/kprunner
       args: ["$(GITHUB_PAT)"]
       env:
@@ -17,5 +17,7 @@ spec:
               name: runner-secrets
               key: gh_runner_pat
               optional: false
+        - name: RUNNER_REPO
+          value: "CSCfi/kielipankki-nlf-harvester"
   securityContext:
     runAsUser: 1031660001


### PR DESCRIPTION
The course-runner has pandoc etc installed so that it can compile CSC-themed slides and pretty vanilla/github-themed standard HTML pages from markdown files. The latter required a bit of a custom solution, as the "normal" jekyll way of publishing pages relies on running containers, which is not feasible from within our own container.