### PR TITLE
KP-8722 Migrate runners to Rahti2

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,17 @@ docker build runners/python-runner -t python-runner
 
 ### Upload the Container Image to Rahti
 Before uploading you need to authenticate. Authentication command and token are
-shown in the [container registry
-UI](https://registry-console.rahti.csc.fi/registry#/?namespace=kielipankki-github-runners).
-After that you can tag the container and push it to the registry, e.g. for the
+shown in the [web UI](https://console-openshift-console.apps.2.rahti.csc.fi/),
+after which you can log in to container registry using
+```
+docker login -p $(oc whoami -t ) -u unused image-registry.apps.2.rahti.csc.fi
+```
+
+You can tag the container and push it to the registry, e.g. for the
 basic python runner:
 ```
-docker tag python-runner docker-registry.rahti.csc.fi/kielipankki-github-runners/python-runner:[VERSION]
-docker push docker-registry.rahti.csc.fi/kielipankki-github-runners/python-runner:[VERSION]
+docker tag python-runner image-registry.apps.2.rahti.csc.fi/kp-gh-actions-runners/python-runner:[VERSION]
+docker push image-registry.apps.2.rahti.csc.fi/kp-gh-actions-runners/python-runner:[VERSION]
 ```
 You can check the previous version from [the container
 registry](https://registry-console.rahti.csc.fi/registry#/?namespace=kielipankki-github-runners):

--- a/runners/course-runner/Dockerfile
+++ b/runners/course-runner/Dockerfile
@@ -12,10 +12,10 @@ RUN export LC_ALL=fi_FI.utf8
 
 # GitHub actions runner
 
-ARG ACTIONS_RUNNER_VERSION="2.306.0"
-ARG ACTIONS_RUNNER_CHECKSUM="b0a090336f0d0a439dac7505475a1fb822f61bbb36420c7b3b3fe6b1bdc4dbaa"
+ARG ACTIONS_RUNNER_VERSION="2.317.0"
+ARG ACTIONS_RUNNER_CHECKSUM="9e883d210df8c6028aff475475a457d380353f9d01877d51cc01a17b2a91161d"
 
-RUN useradd --home-dir /home/kprunner --create-home --no-log-init -u 1031660001 kprunner
+RUN useradd --home-dir /home/kprunner --create-home --no-log-init -u 1002480001 kprunner
 USER kprunner
 
 RUN mkdir /home/kprunner/runner

--- a/runners/python-runner/Dockerfile
+++ b/runners/python-runner/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
-ARG ACTIONS_RUNNER_VERSION="2.312.0"
-ARG ACTIONS_RUNNER_CHECKSUM="85c1bbd104d539f666a89edef70a18db2596df374a1b51670f2af1578ecbe031"
+ARG ACTIONS_RUNNER_VERSION="2.317.0"
+ARG ACTIONS_RUNNER_CHECKSUM="9e883d210df8c6028aff475475a457d380353f9d01877d51cc01a17b2a91161d"
 
 RUN export LANG=fi_FI.utf8
 RUN export LC_ALL=fi_FI.utf8
@@ -14,7 +14,7 @@ RUN apt-get update -y \
   && apt-get upgrade -y \
   && apt-get install curl wget libssl-dev libdigest-sha-perl jq -y
 
-RUN useradd --home-dir /home/kprunner --create-home --no-log-init -u 1031660001 kprunner
+RUN useradd --home-dir /home/kprunner --create-home --no-log-init -u 1002480001 kprunner
 
 
 # Runner software

--- a/services/course-runner-pod.yaml
+++ b/services/course-runner-pod.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: runner-container
-      image: "docker-registry.default.svc:5000/kielipankki-github-runners/course-runner:v1.1.0"
+      image: "image-registry.apps.2.rahti.csc.fi/kp-gh-actions-runners/course-runner:v1.1.1"
       workingDir: /home/kprunner
       args: ["$(GITHUB_PAT)"]
       env:
@@ -20,4 +20,4 @@ spec:
         - name: RUNNER_REPO
           value: "csc-training/Kielipankki"
   securityContext:
-    runAsUser: 1031660001
+    runAsUser: 1002480001

--- a/services/python-runner-pod.yaml
+++ b/services/python-runner-pod.yaml
@@ -24,6 +24,13 @@ objects:
                   optional: false
             - name: RUNNER_REPO
               value: ${REPO_OWNER}/${REPO_NAME}
+          resources:
+            limits:
+              cpu: "250m"
+              memory: "500Mi"
+            requests:
+              cpu: "50m"
+              memory: "100Mi"
       securityContext:
         runAsUser: 1002480001
 parameters:

--- a/services/python-runner-pod.yaml
+++ b/services/python-runner-pod.yaml
@@ -12,7 +12,7 @@ objects:
     spec:
       containers:
         - name: runner-container
-          image: "docker-registry.default.svc:5000/kielipankki-github-runners/python-runner:v1.1.2"
+          image: "image-registry.apps.2.rahti.csc.fi/kp-gh-actions-runners/python-runner:v1.1.4"
           workingDir: /home/kprunner
           args: ["$(GITHUB_PAT)"]
           env:
@@ -25,7 +25,7 @@ objects:
             - name: RUNNER_REPO
               value: ${REPO_OWNER}/${REPO_NAME}
       securityContext:
-        runAsUser: 1031660001
+        runAsUser: 1002480001
 parameters:
   - name: REPO_OWNER
     required: true


### PR DESCRIPTION
The pods can now be created in Rahti 2 and the readme has been updated to describe the altered process. Most notable change was that the allowed UID ranges have changed.

Resource quotas for python-runner were also adjusted. The jobs done by the python runner are typically pretty light, so the pod doesn't need to get the pretty hefty default resources. These are sufficient for running the tests and static analysis in metax-bridge (with CPU usage staying below 150 millicores and memory usage peaking at around 170 MiB), but it possible that some heavier test suites require increasing the resource allocations.

Course runner resources were not touched, because
1. it's more work to test it
2. it's not clear when (or whether) we use it the next time, so there's
   not much to gain

Runner versions were also updated now that there was a natural chance to do that.